### PR TITLE
[RAC-5698] rackhd / swagger-ui / displays invalid in the UI although authenticated

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -32,6 +32,11 @@
 
   <script type="text/javascript">
     $(function () {
+      loginToMonorail().always(function(token) {
+          if(token.status === 404){
+              $('#auth').hide();
+          }
+      });
       function log() {
         if ('console' in window) {
           console.log.apply(console, arguments);


### PR DESCRIPTION
**Background**
currently the RackHD swagger UI shows invalid although user has been authenticated
only the Redfish API Key is populated in the UI
the faulty display does not appear to affect swagger usability
user still has access to the 2.0 API
this is a regression
see screen capture attached
![image](https://user-images.githubusercontent.com/20394473/29619855-c33d1444-884e-11e7-8231-27145a981ccf.png)

Pair with @mcgg
**Details**
@iceiilin ,@mcgg and me discuss the solution. 
1) when authEnabled is false in the file /opt/monorail/config.json line 16, the Redfish API Key, username and password input will not be displayed.
2) when authEnabled is true in the file /opt/monorail/config.json line 16, the token will be shown as follows.
![image](https://user-images.githubusercontent.com/20394473/29620475-96b52b9e-8850-11e7-9d6a-446d7edf004e.png)

**Reviewers**
@iceiilin @pengz1 @mcgg